### PR TITLE
Remove the rest of Aura

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1645,49 +1645,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cumulus-client-consensus-aura"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fbbba68555835c2e2d7f1c17060d3cd6fafafdb16597a2e680e7376f71dec51"
-dependencies = [
- "async-trait",
- "cumulus-client-collator",
- "cumulus-client-consensus-common",
- "cumulus-client-consensus-proposer",
- "cumulus-client-parachain-inherent",
- "cumulus-primitives-aura",
- "cumulus-primitives-core",
- "cumulus-relay-chain-interface",
- "futures",
- "parity-scale-codec",
- "polkadot-node-primitives",
- "polkadot-node-subsystem",
- "polkadot-overseer",
- "polkadot-primitives",
- "sc-client-api",
- "sc-consensus",
- "sc-consensus-aura",
- "sc-consensus-babe",
- "sc-consensus-slots",
- "sc-telemetry",
- "schnellru",
- "sp-api",
- "sp-application-crypto",
- "sp-block-builder",
- "sp-blockchain",
- "sp-consensus",
- "sp-consensus-aura",
- "sp-core",
- "sp-inherents",
- "sp-keystore",
- "sp-runtime",
- "sp-state-machine",
- "sp-timestamp",
- "substrate-prometheus-endpoint",
- "tracing",
-]
-
-[[package]]
 name = "cumulus-client-consensus-common"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1869,25 +1826,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cumulus-pallet-aura-ext"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47ec277f09a2c2b693bca6283eb6bc10aede2eaee43a7c395911235d8b632dab"
-dependencies = [
- "cumulus-pallet-parachain-system",
- "frame-support",
- "frame-system",
- "pallet-aura",
- "pallet-timestamp",
- "parity-scale-codec",
- "scale-info",
- "sp-application-crypto",
- "sp-consensus-aura",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1976,21 +1914,6 @@ dependencies = [
  "sp-std",
  "staging-xcm",
  "staging-xcm-executor",
-]
-
-[[package]]
-name = "cumulus-primitives-aura"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b70d13f3fca1dfaeb868f4fff79c58fef8fa4f8e381a9002d93c50c23683abf"
-dependencies = [
- "parity-scale-codec",
- "polkadot-core-primitives",
- "polkadot-primitives",
- "sp-api",
- "sp-consensus-aura",
- "sp-runtime",
- "sp-std",
 ]
 
 [[package]]
@@ -2425,11 +2348,9 @@ name = "devnet-runtime"
 version = "0.1.0"
 dependencies = [
  "assets-common",
- "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcm",
  "cumulus-pallet-xcmp-queue",
- "cumulus-primitives-aura",
  "cumulus-primitives-core",
  "cumulus-primitives-timestamp",
  "cumulus-primitives-utility",
@@ -2443,7 +2364,6 @@ dependencies = [
  "hex-literal",
  "log",
  "pallet-assets",
- "pallet-aura",
  "pallet-balances",
  "pallet-collective",
  "pallet-message-queue",
@@ -2468,7 +2388,6 @@ dependencies = [
  "smallvec",
  "sp-api",
  "sp-block-builder",
- "sp-consensus-aura",
  "sp-core",
  "sp-genesis-builder",
  "sp-inherents",
@@ -5156,11 +5075,9 @@ name = "mainnet-runtime"
 version = "0.1.0"
 dependencies = [
  "assets-common",
- "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcm",
  "cumulus-pallet-xcmp-queue",
- "cumulus-primitives-aura",
  "cumulus-primitives-core",
  "cumulus-primitives-timestamp",
  "cumulus-primitives-utility",
@@ -5174,7 +5091,6 @@ dependencies = [
  "hex-literal",
  "log",
  "pallet-assets",
- "pallet-aura",
  "pallet-balances",
  "pallet-collective",
  "pallet-message-queue",
@@ -5199,7 +5115,6 @@ dependencies = [
  "smallvec",
  "sp-api",
  "sp-block-builder",
- "sp-consensus-aura",
  "sp-core",
  "sp-genesis-builder",
  "sp-inherents",
@@ -6013,24 +5928,6 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-aura"
-version = "30.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3f1176f435a94b510b99bc2aaaa84788d60f8c5352c5f34f165b37523e448a1"
-dependencies = [
- "frame-support",
- "frame-system",
- "log",
- "pallet-timestamp",
- "parity-scale-codec",
- "scale-info",
- "sp-application-crypto",
- "sp-consensus-aura",
  "sp-runtime",
  "sp-std",
 ]
@@ -7203,13 +7100,11 @@ dependencies = [
  "color-print",
  "cumulus-client-cli",
  "cumulus-client-collator",
- "cumulus-client-consensus-aura",
  "cumulus-client-consensus-common",
  "cumulus-client-consensus-proposer",
  "cumulus-client-consensus-relay-chain",
  "cumulus-client-parachain-inherent",
  "cumulus-client-service",
- "cumulus-primitives-aura",
  "cumulus-primitives-core",
  "cumulus-primitives-parachain-inherent",
  "cumulus-relay-chain-inprocess-interface",
@@ -7251,7 +7146,6 @@ dependencies = [
  "sp-api",
  "sp-block-builder",
  "sp-blockchain",
- "sp-consensus-aura",
  "sp-core",
  "sp-io",
  "sp-keystore",
@@ -10223,36 +10117,6 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-state-machine",
- "substrate-prometheus-endpoint",
- "thiserror",
-]
-
-[[package]]
-name = "sc-consensus-aura"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "988701c58dcd9521412cfcbb54457b17546bb4363f021ee8131af409a027b879"
-dependencies = [
- "async-trait",
- "futures",
- "log",
- "parity-scale-codec",
- "sc-block-builder",
- "sc-client-api",
- "sc-consensus",
- "sc-consensus-slots",
- "sc-telemetry",
- "sp-api",
- "sp-application-crypto",
- "sp-block-builder",
- "sp-blockchain",
- "sp-consensus",
- "sp-consensus-aura",
- "sp-consensus-slots",
- "sp-core",
- "sp-inherents",
- "sp-keystore",
- "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ frame-system = { version = "31.0.0", default-features = false }
 frame-system-benchmarking = { version = "31.0.0", default-features = false }
 frame-system-rpc-runtime-api = { version = "29.0.0", default-features = false }
 frame-try-runtime = { version = "0.37.0", default-features = false }
-pallet-aura = { version = "30.0.0", default-features = false }
 pallet-assets = { version = "32.0.0", default-features = false }
 pallet-balances = { version = "31.0.0", default-features = false }
 pallet-collective = { version = "31.0.0", default-features = false }
@@ -79,7 +78,6 @@ sc-offchain = { version = "32.0.0" }
 sp-api = { version = "29.0.0", default-features = false }
 sp-block-builder = { version = "29.0.0", default-features = false }
 sp-blockchain = { version = "31.0.0" }
-sp-consensus-aura = { version = "0.35.0", default-features = false }
 sp-core = { version = "31.0.0", default-features = false }
 sp-genesis-builder = { version = "0.10.0", default-features = false }
 sp-inherents = { version = "29.0.0", default-features = false }
@@ -101,18 +99,15 @@ try-runtime-cli = { version = "0.41.0" }
 # Cumulus
 assets-common = { version = "0.10.0", default-features = false }
 cumulus-client-cli = { version = "0.10.0" }
-cumulus-client-consensus-aura = { version = "0.10.0" }
 cumulus-client-consensus-common = { version = "0.10.0" }
 cumulus-client-consensus-relay-chain = { version = "0.10.0" }
 cumulus-client-collator = { version = "0.10.0" }
 cumulus-client-parachain-inherent = { version = "0.4.0" }
 cumulus-client-service = { version = "0.10.0" }
 cumulus-client-consensus-proposer = { version = "0.10.0" }
-cumulus-pallet-aura-ext = { version = "0.10.0", default-features = false }
 cumulus-pallet-parachain-system = { version = "0.10.0", default-features = false }
 cumulus-pallet-xcm = { version = "0.10.0", default-features = false }
 cumulus-pallet-xcmp-queue = { version = "0.10.0", default-features = false }
-cumulus-primitives-aura = { version = "0.10.0", default-features = false }
 cumulus-primitives-core = { version = "0.10.0", default-features = false }
 cumulus-primitives-parachain-inherent = { version = "0.10.0" }
 cumulus-primitives-timestamp = { version = "0.10.0", default-features = false }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -48,7 +48,6 @@ sc-transaction-pool-api = { workspace = true }
 sp-api = { workspace = true }
 sp-block-builder = { workspace = true }
 sp-blockchain = { workspace = true }
-sp-consensus-aura = { workspace = true }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
 sp-keystore = { workspace = true }
@@ -69,13 +68,11 @@ xcm = { workspace = true, default-features = false }
 
 # Cumulus
 cumulus-client-cli = { workspace = true }
-cumulus-client-consensus-aura = { workspace = true }
 cumulus-client-consensus-common = { workspace = true }
 cumulus-client-consensus-relay-chain = { workspace = true }
 cumulus-client-collator = { workspace = true }
 cumulus-client-parachain-inherent = { workspace = true }
 cumulus-client-service = { workspace = true }
-cumulus-primitives-aura = { workspace = true }
 cumulus-primitives-core = { workspace = true }
 cumulus-primitives-parachain-inherent = { workspace = true }
 cumulus-client-consensus-proposer = { workspace = true }

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -17,6 +17,8 @@ pub type Nonce = u32;
 /// up by `pallet_aura` to implement `fn slot_duration()`.
 ///
 /// Change this to adjust the block time.
+//
+// TODO: Update comment and/or usage to reflect we don't use aura.
 pub const MILLISECS_PER_BLOCK: u64 = 6000;
 
 // NOTE: Currently it is not possible to change the slot duration after the chain has started.

--- a/runtime/devnet/Cargo.toml
+++ b/runtime/devnet/Cargo.toml
@@ -37,7 +37,6 @@ frame-system = { workspace = true, default-features = false }
 frame-system-benchmarking = { workspace = true, default-features = false, optional = true }
 frame-system-rpc-runtime-api = { workspace = true, default-features = false }
 frame-try-runtime = { workspace = true, default-features = false, optional = true }
-pallet-aura = { workspace = true, default-features = false }
 pallet-assets = { workspace = true, default-features = false }
 pallet-balances = { workspace = true, default-features = false }
 pallet-collective = { workspace = true, default-features = false }
@@ -53,7 +52,6 @@ pallet-safe-mode = { workspace = true, default-features = false }
 pallet-tx-pause = { workspace = true, default-features = false }
 sp-api = { workspace = true, default-features = false }
 sp-block-builder = { workspace = true, default-features = false }
-sp-consensus-aura = { workspace = true, default-features = false }
 sp-core = { workspace = true, default-features = false }
 sp-genesis-builder = { workspace = true, default-features = false }
 sp-inherents = { workspace = true, default-features = false }
@@ -74,13 +72,11 @@ xcm-executor = { workspace = true, default-features = false }
 
 # Cumulus
 assets-common = { workspace = true, default-features = false }
-cumulus-pallet-aura-ext = { workspace = true, default-features = false }
 cumulus-pallet-parachain-system = { workspace = true, default-features = false, features = [
   "parameterized-consensus-hook",
 ] }
 cumulus-pallet-xcm = { workspace = true, default-features = false }
 cumulus-pallet-xcmp-queue = { workspace = true, default-features = false }
-cumulus-primitives-aura = { workspace = true, default-features = false }
 cumulus-primitives-core = { workspace = true, default-features = false }
 cumulus-primitives-timestamp = { workspace = true, default-features = false }
 cumulus-primitives-utility = { workspace = true, default-features = false }
@@ -95,11 +91,9 @@ std = [
 	"log/std",
 	"scale-info/std",
 	"assets-common/std",
-	"cumulus-pallet-aura-ext/std",
 	"cumulus-pallet-parachain-system/std",
 	"cumulus-pallet-xcm/std",
 	"cumulus-pallet-xcmp-queue/std",
-	"cumulus-primitives-aura/std",
 	"cumulus-primitives-core/std",
 	"cumulus-primitives-timestamp/std",
 	"cumulus-primitives-utility/std",
@@ -107,7 +101,6 @@ std = [
 	"frame-support/std",
 	"frame-system-rpc-runtime-api/std",
 	"frame-system/std",
-	"pallet-aura/std",
 	"pallet-assets/std",
 	"pallet-balances/std",
 	"pallet-collective/std",
@@ -130,7 +123,6 @@ std = [
 	"polkadot-runtime-common/std",
 	"sp-api/std",
 	"sp-block-builder/std",
-	"sp-consensus-aura/std",
 	"sp-core/std",
 	"sp-genesis-builder/std",
 	"sp-inherents/std",
@@ -171,14 +163,12 @@ runtime-benchmarks = [
 ]
 
 try-runtime = [
-	"cumulus-pallet-aura-ext/try-runtime",
 	"cumulus-pallet-parachain-system/try-runtime",
 	"cumulus-pallet-xcm/try-runtime",
 	"cumulus-pallet-xcmp-queue/try-runtime",
 	"frame-executive/try-runtime",
 	"frame-system/try-runtime",
 	"frame-try-runtime",
-	"pallet-aura/try-runtime",
 	"pallet-assets/try-runtime",
 	"pallet-balances/try-runtime",
 	"pallet-collective/try-runtime",

--- a/runtime/devnet/src/lib.rs
+++ b/runtime/devnet/src/lib.rs
@@ -208,8 +208,8 @@ impl_opaque_keys! {
 
 #[sp_version::runtime_version]
 pub const VERSION: RuntimeVersion = RuntimeVersion {
-	spec_name: create_runtime_str!("mainnet"),
-	impl_name: create_runtime_str!("mainnet"),
+	spec_name: create_runtime_str!("devnet"),
+	impl_name: create_runtime_str!("devnet"),
 	authoring_version: 1,
 	spec_version: 1000,
 	impl_version: 0,

--- a/runtime/mainnet/Cargo.toml
+++ b/runtime/mainnet/Cargo.toml
@@ -37,7 +37,6 @@ frame-system = { workspace = true, default-features = false }
 frame-system-benchmarking = { workspace = true, default-features = false, optional = true }
 frame-system-rpc-runtime-api = { workspace = true, default-features = false }
 frame-try-runtime = { workspace = true, default-features = false, optional = true }
-pallet-aura = { workspace = true, default-features = false }
 pallet-assets = { workspace = true, default-features = false }
 pallet-balances = { workspace = true, default-features = false }
 pallet-collective = { workspace = true, default-features = false }
@@ -53,7 +52,6 @@ pallet-safe-mode = { workspace = true, default-features = false }
 pallet-tx-pause = { workspace = true, default-features = false }
 sp-api = { workspace = true, default-features = false }
 sp-block-builder = { workspace = true, default-features = false }
-sp-consensus-aura = { workspace = true, default-features = false }
 sp-core = { workspace = true, default-features = false }
 sp-genesis-builder = { workspace = true, default-features = false }
 sp-inherents = { workspace = true, default-features = false }
@@ -74,13 +72,11 @@ xcm-executor = { workspace = true, default-features = false }
 
 # Cumulus
 assets-common = { workspace = true, default-features = false }
-cumulus-pallet-aura-ext = { workspace = true, default-features = false }
 cumulus-pallet-parachain-system = { workspace = true, default-features = false, features = [
   "parameterized-consensus-hook",
 ] }
 cumulus-pallet-xcm = { workspace = true, default-features = false }
 cumulus-pallet-xcmp-queue = { workspace = true, default-features = false }
-cumulus-primitives-aura = { workspace = true, default-features = false }
 cumulus-primitives-core = { workspace = true, default-features = false }
 cumulus-primitives-timestamp = { workspace = true, default-features = false }
 cumulus-primitives-utility = { workspace = true, default-features = false }
@@ -95,11 +91,9 @@ std = [
   "log/std",
   "scale-info/std",
   "assets-common/std",
-  "cumulus-pallet-aura-ext/std",
   "cumulus-pallet-parachain-system/std",
   "cumulus-pallet-xcm/std",
   "cumulus-pallet-xcmp-queue/std",
-  "cumulus-primitives-aura/std",
   "cumulus-primitives-core/std",
   "cumulus-primitives-timestamp/std",
   "cumulus-primitives-utility/std",
@@ -107,7 +101,6 @@ std = [
   "frame-support/std",
   "frame-system-rpc-runtime-api/std",
   "frame-system/std",
-  "pallet-aura/std",
   "pallet-assets/std",
   "pallet-balances/std",
   "pallet-collective/std",
@@ -130,7 +123,6 @@ std = [
   "polkadot-runtime-common/std",
   "sp-api/std",
   "sp-block-builder/std",
-  "sp-consensus-aura/std",
   "sp-core/std",
   "sp-genesis-builder/std",
   "sp-inherents/std",
@@ -171,14 +163,12 @@ runtime-benchmarks = [
 ]
 
 try-runtime = [
-  "cumulus-pallet-aura-ext/try-runtime",
   "cumulus-pallet-parachain-system/try-runtime",
   "cumulus-pallet-xcm/try-runtime",
   "cumulus-pallet-xcmp-queue/try-runtime",
   "frame-executive/try-runtime",
   "frame-system/try-runtime",
   "frame-try-runtime",
-  "pallet-aura/try-runtime",
   "pallet-assets/try-runtime",
   "pallet-balances/try-runtime",
   "pallet-collective/try-runtime",


### PR DESCRIPTION
In https://github.com/polkadot-dropit/node/pull/2, not all of Aura was removed.

This cleans up the rest of it.