### PR TITLE
Initial XCM Config

### DIFF
--- a/runtime/src/xcm_config.rs
+++ b/runtime/src/xcm_config.rs
@@ -40,8 +40,8 @@ pub type LocationToAccountId = (
 	AccountId32Aliases<RelayNetwork, AccountId>,
 );
 
-// These configurations make Reserve Backed DOT/KSM to be the native token of this chain.
-pub mod use_dot_as_native {
+// These configurations make reserve backed relay token to be the native token of this chain.
+pub mod use_relay_as_native {
 	use super::*;
 
 	/// AssetTransactor for handling the relay chain token
@@ -143,9 +143,9 @@ impl xcm_executor::Config for XcmConfig {
 	type RuntimeCall = RuntimeCall;
 	type XcmSender = XcmRouter;
 	// How to withdraw and deposit an asset.
-	type AssetTransactor = use_dot_as_native::AssetTransactor<Balances>;
+	type AssetTransactor = use_relay_as_native::AssetTransactor<Balances>;
 	type OriginConverter = XcmOriginToTransactDispatchOrigin;
-	type IsReserve = use_dot_as_native::IsReserve;
+	type IsReserve = use_relay_as_native::IsReserve;
 	type IsTeleporter = (); // Teleporting is disabled.
 	type UniversalLocation = UniversalLocation;
 	type Barrier = Barrier;


### PR DESCRIPTION
- Using the [xcm cookbook](https://github.com/paritytech/polkadot-sdk/pull/2633/files#diff-d5bbfbd02748425c0fef7e291347b8e52e94679f8f184780a0c84ae9792ce04c) set reserved backed DOT as a native token of our chain.